### PR TITLE
fix-mirror-integration: update to non-nullable network messages

### DIFF
--- a/Assets/MasterServerToolkit/Bridges/Mirror/Scripts/Messages/CreatePlayerMessage.cs
+++ b/Assets/MasterServerToolkit/Bridges/Mirror/Scripts/Messages/CreatePlayerMessage.cs
@@ -3,7 +3,7 @@ using Mirror;
 
 namespace MasterServerToolkit.Bridges.MirrorNetworking
 {
-    public class CreatePlayerMessage : NetworkMessage
+    public struct CreatePlayerMessage : NetworkMessage
     {
         
     }

--- a/Assets/MasterServerToolkit/Bridges/Mirror/Scripts/Messages/ValidateRoomAccessRequestMessage.cs
+++ b/Assets/MasterServerToolkit/Bridges/Mirror/Scripts/Messages/ValidateRoomAccessRequestMessage.cs
@@ -7,13 +7,8 @@ using UnityEngine;
 
 namespace MasterServerToolkit.Bridges.MirrorNetworking
 {
-    public class ValidateRoomAccessRequestMessage : NetworkMessage
+    public struct ValidateRoomAccessRequestMessage : NetworkMessage
     {
-        public ValidateRoomAccessRequestMessage()
-        {
-            Token = string.Empty;
-        }
-
         public ValidateRoomAccessRequestMessage(string token)
         {
             Token = token ?? throw new ArgumentNullException(nameof(token));

--- a/Assets/MasterServerToolkit/Bridges/Mirror/Scripts/Messages/ValidateRoomAccessResultMessage.cs
+++ b/Assets/MasterServerToolkit/Bridges/Mirror/Scripts/Messages/ValidateRoomAccessResultMessage.cs
@@ -4,7 +4,7 @@ using Mirror;
 
 namespace MasterServerToolkit.Bridges.MirrorNetworking
 {
-    public class ValidateRoomAccessResultMessage : NetworkMessage
+    public struct ValidateRoomAccessResultMessage : NetworkMessage
     {
         public string Error { get; set; }
         public ResponseStatus Status { get; set; }


### PR DESCRIPTION
This PR fix the bug related with the new Mirror Version (30.5.3). 

`Assets/MasterServerToolkit/Bridges/Mirror/Scripts/Room/RoomServer.cs(473,26): error CS0453: The type 'ValidateRoomAccessResultMessage' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'NetworkConnection.Send<T>(T, int)'`

Every message needs to be struct.