### PR TITLE
fix(mongodb): add method GetAccountByDeviceIdAsync and fields Deviced and DeviceName

### DIFF
--- a/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/AccountsDatabaseAccessor.cs
+++ b/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/AccountsDatabaseAccessor.cs
@@ -107,6 +107,17 @@ namespace MasterServerToolkit.Bridges.MongoDB
                 return _accountsCollection.Find(filter).FirstOrDefault();
             });
         }
+
+        public async Task<IAccountInfoData> GetAccountByDeviceIdAsync(string deviceId)
+        {
+            var filter = Builders<AccountInfoMongoDB>.Filter.Eq(e => e.DeviceId,deviceId.ToLower());
+            return await Task.Run(() =>
+            {
+                return _accountsCollection.Find(filter).FirstOrDefault();
+            });
+        }
+
+        
         
 
         public async Task<IEnumerable<IAccountInfoData>> GetAccountsByIdAsync(IEnumerable<string> ids)

--- a/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/Models/AccountInfoMongoDB.cs
+++ b/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/Models/AccountInfoMongoDB.cs
@@ -19,6 +19,8 @@ namespace MasterServerToolkit.Bridges.MongoDB
         public string PhoneNumber { get; set; }
         public string Facebook { get; set; }
         public string Token { get; set; }
+        public string DeviceId { get; set; }
+        public string DeviceName { get; set; }
         public bool IsAdmin { get; set; }
         public bool IsGuest { get; set; }
         public bool IsEmailConfirmed { get; set; }


### PR DESCRIPTION
This PR updates the MongoDB Bridge Support increasing the new method GetAccountByDeviceIdAsync and the fields 
DeviceId and DeviceName according with the latest DB update.