### PR TITLE
Profile serialiaze to mongo as dictionary of strings

### DIFF
--- a/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/Models/ProfileInfoDocumentMongoDB.cs
+++ b/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/Models/ProfileInfoDocumentMongoDB.cs
@@ -1,0 +1,21 @@
+#if (!UNITY_WEBGL && !UNITY_IOS) || UNITY_EDITOR
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Options;
+
+namespace MasterServerToolkit.Bridges.MongoDB
+{
+    public class ProfileInfoDocumentMongoDB
+    {
+        [BsonId]
+        public ObjectId _id { get; set; }
+        public string Id { get => _id.ToString(); set => _id = new ObjectId(value); }
+
+        public string UserId { get; set; }
+
+        [BsonDictionaryOptions(DictionaryRepresentation.Document)]
+        public Dictionary<string, string> Document { get; set; }
+    }
+}
+#endif

--- a/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/Models/ProfileInfoDocumentMongoDB.cs.meta
+++ b/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/Models/ProfileInfoDocumentMongoDB.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4d3f2c5503304c36b893283e7eb1199e
+timeCreated: 1718891008

--- a/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/ProfilesDatabaseAccessorFactory.cs
+++ b/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/ProfilesDatabaseAccessorFactory.cs
@@ -9,6 +9,7 @@ namespace MasterServerToolkit.Bridges.MongoDB
 
         [Header("Components"), SerializeField]
         private MongoDbClientFactory mongoDbClientFactory;
+        [SerializeField] private bool saveDataAsBytes = true;
 
         #endregion
 
@@ -17,7 +18,10 @@ namespace MasterServerToolkit.Bridges.MongoDB
 #if (!UNITY_WEBGL && !UNITY_IOS) || UNITY_EDITOR
             try
             {
-                Mst.Server.DbAccessors.AddAccessor(new ProfilesDatabaseAccessor(mongoDbClientFactory.Client, mongoDbClientFactory.Database));
+                if(saveDataAsBytes) 
+                    Mst.Server.DbAccessors.AddAccessor(new ProfilesDatabaseAccessor(mongoDbClientFactory.Client, mongoDbClientFactory.Database));
+                else
+                    Mst.Server.DbAccessors.AddAccessor(new ProfilesDocumentDatabaseAccessor(mongoDbClientFactory.Client, mongoDbClientFactory.Database));
             }
             catch (System.Exception e)
             {

--- a/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/ProfilesDatabaseAccessorFactory.cs
+++ b/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/ProfilesDatabaseAccessorFactory.cs
@@ -9,7 +9,7 @@ namespace MasterServerToolkit.Bridges.MongoDB
 
         [Header("Components"), SerializeField]
         private MongoDbClientFactory mongoDbClientFactory;
-        [SerializeField] private bool saveDataAsBytes = true;
+        [SerializeField] private bool saveDataAsBytes;
 
         #endregion
 

--- a/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/ProfilesDocumentDatabaseAccessor.cs
+++ b/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/ProfilesDocumentDatabaseAccessor.cs
@@ -1,0 +1,95 @@
+﻿#if (!UNITY_WEBGL && !UNITY_IOS) || UNITY_EDITOR
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MasterServerToolkit.Extensions;
+using MasterServerToolkit.Logging;
+using MasterServerToolkit.MasterServer;
+using MongoDB.Driver;
+
+namespace MasterServerToolkit.Bridges.MongoDB
+{
+    public class ProfilesDocumentDatabaseAccessor : IProfilesDatabaseAccessor
+    {
+        private MongoClient _client;
+        private IMongoDatabase _database;
+
+        private IMongoCollection<ProfileInfoDocumentMongoDB> _profiles;
+
+        public MstProperties CustomProperties { get; private set; } = new MstProperties();
+        public Logger Logger { get; set; }
+
+        public ProfilesDocumentDatabaseAccessor(string connectionString, string databaseName)
+            : this(new MongoClient(connectionString), databaseName) { }
+
+        public ProfilesDocumentDatabaseAccessor(MongoClient client, string databaseName)
+        {
+            _client = client;
+            _database = _client.GetDatabase(databaseName);
+
+            _profiles = _database.GetCollection<ProfileInfoDocumentMongoDB>("profiles");
+
+            _profiles.Indexes.CreateOne(
+                new CreateIndexModel<ProfileInfoDocumentMongoDB>(
+                    Builders<ProfileInfoDocumentMongoDB>.IndexKeys.Ascending(e => e.UserId), new CreateIndexOptions() { Unique = true }
+                )
+            );
+        }
+
+        public void Dispose() { }
+
+        public async Task RestoreProfileAsync(ObservableServerProfile profile)
+        {
+            try
+            {
+                var data = await FindOrCreateData(profile);
+                var document = data.Document.ToDictionary(x => x.Key.ToUint16Hash(), x => x.Value);
+                profile.FromStrings(document);
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogError(e);
+            }
+        }
+
+        public async Task UpdateProfileAsync(ObservableServerProfile profile)
+        {
+            var data = await FindOrCreateData(profile);
+            data.Document = profile.ToDictionary(x => StringExtensions.FromHash(x.Key), x => x.Serialize());
+
+            var filter = Builders<ProfileInfoDocumentMongoDB>.Filter.Eq(e => e.UserId, profile.UserId);
+
+            await Task.Run(() =>
+            {
+                _profiles.ReplaceOne(filter, data);
+            });
+        }
+
+        private async Task<ProfileInfoDocumentMongoDB> FindOrCreateData(ObservableServerProfile profile)
+        {
+            string userId = profile.UserId;
+
+            var data = await Task.Run(() =>
+            {
+                return _profiles.Find(a => a.UserId == userId).FirstOrDefault();
+            });
+
+            if (data == null)
+            {
+                data = new ProfileInfoDocumentMongoDB()
+                {
+                    UserId = profile.UserId,
+                    Document = profile.ToDictionary(x => StringExtensions.FromHash(x.Key), x => x.Serialize())
+                };
+
+                await Task.Run(() =>
+                {
+                    _profiles.InsertOne(data);
+                });
+            }
+
+            return data;
+        }
+    }
+}
+#endif

--- a/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/ProfilesDocumentDatabaseAccessor.cs.meta
+++ b/Assets/MasterServerToolkit/Bridges/MongoDB/Scripts/ProfilesDocumentDatabaseAccessor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ce75254434264b178c77d377c1dffb48
+timeCreated: 1718890226


### PR DESCRIPTION
When use mongo with profile module - profiles save to mongo as binary.
![robo3t_qTpOqMVLWw](https://github.com/aevien/master-server-toolkit/assets/61922642/4d858122-9c7b-46ce-a888-75ceb1ac468f)

This feature serializing profile properties as dictionary of strings

![robo3t_3c3sxBQe1D](https://github.com/aevien/master-server-toolkit/assets/61922642/24c952a4-5e04-41b2-afe4-ed4a434c8187)
